### PR TITLE
Fixed default Question/Answer display count to match requirements

### DIFF
--- a/client/src/components/QA/AnswerContainer.jsx
+++ b/client/src/components/QA/AnswerContainer.jsx
@@ -5,7 +5,7 @@ import AInfo from './AInfo.jsx';
 import ResponsePhotos from './ResponsePhotos.jsx';
 
 const AnswerContainer = ({ data }) => {
-  const [answerCount, setAnswerCount] = useState(1);
+  const [answerCount, setAnswerCount] = useState(2);
 
     return (
       <div key={data.id} className='answer-container'>

--- a/client/src/components/QA/QContainer.jsx
+++ b/client/src/components/QA/QContainer.jsx
@@ -14,7 +14,7 @@ const QContainer = ({
 
   const handleExpandLess = () => {
     var cop = {...answerCount};
-    cop[id] = 1;
+    cop[id] = 2;
     setAnswerCount(cop);
 
   }

--- a/client/src/components/QA/QuestionAnswers.jsx
+++ b/client/src/components/QA/QuestionAnswers.jsx
@@ -20,7 +20,7 @@ import { QuestionsContext } from '../../contexts/question.context.jsx';
 
 const QuestionAnswers = () => {
   const { productID, results } = useContext(QuestionsContext);
-  const [questionCount, setQuestionCount] = useState(2);
+  const [questionCount, setQuestionCount] = useState(4);
   const [countLimit, setCountLimit] = useState({});
   const [answerCount, setAnswerCount] = useState({});
   const [answerLimit, setAnswerLimit] = useState({});
@@ -30,7 +30,7 @@ const QuestionAnswers = () => {
       const temp = {};
       const tempTwo = {};
       results.forEach(({ question_id, answers }) => {
-        temp[question_id] = 1;
+        temp[question_id] = 2;
         tempTwo[question_id] = Object.keys(answers).length;
       })
       setAnswerCount(temp);


### PR DESCRIPTION
By default, on page load up to four questions should be displayed. Up to two answers should display for each question. The remaining questions or answers should be hidden until the user loads them using the “More Answered Questions” button