### PR TITLE
Fix Question Modal name field to match requirements

### DIFF
--- a/client/src/components/QA/QuestionModal.jsx
+++ b/client/src/components/QA/QuestionModal.jsx
@@ -13,6 +13,13 @@ const QuestionModal = ({ open, product_id, onClose }) => {
   const [email, setEmail] = useState('');
   const [body, setBody] = useState('');
 
+
+  const handleNameChange = (e) => {
+    if (e.target.value.length <= 60) {
+      setName(e.target.value)
+    }
+  }
+
   const handleBodyField = (e) => {
     if (e.target.value.length <= 1000) {
       setBody(e.target.value)
@@ -56,9 +63,13 @@ const QuestionModal = ({ open, product_id, onClose }) => {
             <input
               value={name}
               type='text'
-              placeholder='Enter Name...'
-              onChange={(e) => setName(e.target.value)}
+              placeholder='Example: jackson11!'
+              onChange={handleNameChange}
             ></input>
+            {name ?
+              <p className='name-message'>For privacy reasons, do not use your full name or email address</p> :
+              <></>
+            }
           </label>
           <label>
             Email:


### PR DESCRIPTION
1. Name field allows up to 60 characters
2. Message on bottom of name field will appear when user begins to type a message
3. Placeholder changed to match requirements